### PR TITLE
opsi-winst-manual: ExecWith: small improvements

### DIFF
--- a/de/opsi-winst-manual/opsi-winst-manual.asciidoc
+++ b/de/opsi-winst-manual/opsi-winst-manual.asciidoc
@@ -9895,9 +9895,9 @@ Diese Option hat den Effekt (wie bei `winBatch` Aufrufen), dass das aufgerufene 
 
 Wie bei ExecPython Sektionen wird die Ausgabe einer ExecWith-Sektion in einer String-Liste über die Funktion `getOutStreamFromSection` erfasst.
 
-Der Inhalt der Sektion wird in eine temporäre Datei (*.bat) gespeichert. Seit Version 4.11.3.5 wird, wenn im angegebene Interpreterpfad 'powershell.exe' vorkommt, die temporäre Datei als `.ps1` gespeichert. 
+Der Inhalt der Sektion wird in eine temporäre Datei (`.cmd`) gespeichert. Seit Version 4.11.3.5 wird, wenn im angegebene Interpreterpfad 'powershell.exe' vorkommt, die temporäre Datei als `.ps1` gespeichert.
 
-Note:: Die Ausführung von Skripten ist in der  Powershell per default ausgeschaltet. Um eine Execwith Sektion mit powershell nutzen zu können, muß die Skriptausführung erst erlaubt werden. Dazu führen Sie `powershell.exe set-executionpolicy RemoteSigned` in einer DosInAnIcon Sektion aus. +
+Note:: Die Ausführung von Skripten ist in der  Powershell per default ausgeschaltet. Um eine Execwith Sektion mit powershell nutzen zu können, muß die Skriptausführung erst erlaubt werden. Das kann durch einen temporären `Bypass` beim Aufruf geschehen, indem man die `ExecWith`-Sektion als `ExecWith_name "powershell.exe" -ExecutionPolicy Bypass` aufruft, oder durch das vorherige Setzen der `ExecutionPolicy` wie folgt. +
 Beispiel
 [source,winst]
 ----

--- a/en/opsi-winst-manual/opsi-winst-manual.asciidoc
+++ b/en/opsi-winst-manual/opsi-winst-manual.asciidoc
@@ -9937,8 +9937,7 @@ The following example call the 64Bit version of the powershell.exe.
 ExecWith_do_64bit_stuff "%System%\WindowsPowerShell\v1.0\powershell.exe" winst /64Bit
 ----
 
-Note:: For Powershell the script execution is disabled by default. So you have to enable it before you can use Execwith with powershell.
-In order to to that you shold call `powershell.exe set-executionpolicy RemoteSigned` in a DosInAnIcon. +
+Note:: For Powershell the script execution is disabled by default. So you have to enable it before you can use Execwith with powershell. To achieve that there are two options: Either call the section using `ExecWith_name "powershell.exe" -ExecutionPolicy Bypass` to temporarily allow execution or enable it permanently using `DosInAnIcon` beforehand. +
 Example
 [source,winst]
 ----


### PR DESCRIPTION
* fix mistake in german version (extension is .cmd not .bat for
  ExecWith)
* add alternative solution to calling powershell.exe set-executionpolicy
  which is shorter

Unfortunately I couldn't add a French translation as I don't speak that language.